### PR TITLE
Minor: optimisation, compute r^2 once.

### DIFF
--- a/src/pixel_sand/main.rs
+++ b/src/pixel_sand/main.rs
@@ -138,6 +138,7 @@ impl ParticleGrid {
         probability: f64,
     ) {
         let r = r as i64;
+        let r2 = r * r;
 
         for dy in -r..=r {
             for dx in -r..=r {
@@ -148,7 +149,7 @@ impl ParticleGrid {
                     continue;
                 }
 
-                if dx * dx + dy * dy <= r * r {
+                if dx * dx + dy * dy <= r2 {
                     if rand.gen::<f64>() < probability {
                         let particle = Particle::Sand(Sand::new(rand, base_color));
                         self.set_particle(x as u32, y as u32, particle);


### PR DESCRIPTION
Just a minor optimization seen while reading the code 

inside add_sand_particles()

When r = 10, r*r will be computed 100 times, RUSTs optimizer may well take care of it but I favour 
making these things explicit.

```
-if dx * dx + dy * dy <= r * r {
+if dx * dx + dy * dy <= r2 {
```
